### PR TITLE
Fix strict MIME type checking stops js file from loading

### DIFF
--- a/src/ControlUIKitServiceProvider.php
+++ b/src/ControlUIKitServiceProvider.php
@@ -74,7 +74,7 @@ class ControlUIKitServiceProvider extends ServiceProvider
                 <script src="https://cdn.jsdelivr.net/npm/chart.js@next/dist/chart.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@next/dist/chartjs-chart-matrix.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.1.0-alpha/dist/chartjs-adapter-date-fns.bundle.js"></script>
-                <script src="$control_script_path" type="application/javascript"></script>
+                <script src="$control_script_path" type="text/javascript"></script>
 
                 <!-- todo: we need to fix the styling on the litepicker !-->
                 <style>

--- a/src/ControlUIKitServiceProvider.php
+++ b/src/ControlUIKitServiceProvider.php
@@ -74,7 +74,7 @@ class ControlUIKitServiceProvider extends ServiceProvider
                 <script src="https://cdn.jsdelivr.net/npm/chart.js@next/dist/chart.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@next/dist/chartjs-chart-matrix.js"></script>
                 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@1.1.0-alpha/dist/chartjs-adapter-date-fns.bundle.js"></script>
-                <script src="$control_script_path"></script>
+                <script src="$control_script_path" type="application/javascript"></script>
 
                 <!-- todo: we need to fix the styling on the litepicker !-->
                 <style>

--- a/src/Controllers/ControlUIKitScriptController.php
+++ b/src/Controllers/ControlUIKitScriptController.php
@@ -10,7 +10,9 @@ class ControlUIKitScriptController extends Controller
     {
         $this->disablePackageConflicts();
 
-        return file_get_contents(__DIR__ . '/../../resources/js/control-ui-kit.js');
+        header('Content-Type: text/javascript; charset=UTF8', true);
+        print file_get_contents(__DIR__ . '/../../resources/js/control-ui-kit.js');
+        exit;
     }
 
     private function disablePackageConflicts(): void


### PR DESCRIPTION
This PR fixes the bug where control-ui-kit.js will not load if strict mime type checking is enabled.