### PR TITLE
Fix livewire not updating OTC

### DIFF
--- a/resources/views/control-ui-kit/forms/inputs/one-time-code.blade.php
+++ b/resources/views/control-ui-kit/forms/inputs/one-time-code.blade.php
@@ -14,7 +14,7 @@
     {{ $attributes->whereStartsWith(['class', 'x-model']) }}>
     <fieldset class="fs-{{ $name }}-otc">
         @for($i = 1; $i <= $digits; $i++)
-            <input id="{{ $name }}-{{ $i }}" data-digit="{{ $i }}" x-model="digit_{{ $i }}" type="number" {{ $attributes->whereDoesntStartWith(['class', 'x-model'])->merge($basicClasses()) }} pattern="[0-9]*" min="0" max="9" maxlength="1"@if($requiredInput) required @endif />
+            <input id="{{ $name }}-{{ $i }}" data-digit="{{ $i }}" x-model="digit_{{ $i }}" type="number" {{ $attributes->whereDoesntStartWith(['class', 'x-model', 'wire:model'])->merge($basicClasses()) }} pattern="[0-9]*" min="0" max="9" maxlength="1" @if($requiredInput) required @endif />
         @endfor
     </fieldset>
     <input type="hidden" name="{{ $name }}" id="{{ $id }}" x-model="value" />


### PR DESCRIPTION
This PR fixes an issue where wire:model is present on individual digits of the one-time-code components when it should not be.