### PR TITLE
Auto Complete Command Stub Updates

### DIFF
--- a/src/AutoComplete.php
+++ b/src/AutoComplete.php
@@ -36,11 +36,31 @@ abstract class AutoComplete
     public function language(): array
     {
         return [
-            'no-results-text' => config('themes.default.input-autocomplete.no-results-text'),
-            'prompt-text' => config('themes.default.input-autocomplete.prompt-text'),
-            'selected-text' => config('themes.default.input-autocomplete.selected-text'),
-            'placeholder' => config('themes.default.input-autocomplete.placeholder'),
+            'no-results-text' => $this->noResultsText(),
+            'prompt-text' => $this->promptText(),
+            'selected-text' => $this->selectedText(),
+            'placeholder' => $this->placeholder(),
         ];
+    }
+
+    protected function noResultsText(): string
+    {
+        return config('themes.default.input-autocomplete.no-results-text');
+    }
+
+    protected function promptText(): string
+    {
+        return config('themes.default.input-autocomplete.prompt-text');
+    }
+
+    protected function selectedText(): string
+    {
+        return config('themes.default.input-autocomplete.selected-text');
+    }
+
+    protected function placeholder(): string
+    {
+        return config('themes.default.input-autocomplete.placeholder');
     }
 
     protected function fields(): array

--- a/stubs/autocomplete.stub
+++ b/stubs/autocomplete.stub
@@ -15,21 +15,11 @@ class {{ class }} extends AutoComplete
     public bool $auto = false;
     public int $count = 20;
 
-    public function language(): array
-    {
-        return [
-            'no-results-text' => config('themes.default.input-autocomplete.no-results-text'),
-            'prompt-text' => config('themes.default.input-autocomplete.prompt-text'),
-            'selected-text' => config('themes.default.input-autocomplete.selected-text'),
-            'placeholder' => config('themes.default.input-autocomplete.placeholder'),
-        ];
-    }
-
     protected function fields(): array
     {
         return [
             'id' => 'id',
-            'text' => 'text',
+            'text' => 'name',
             'subtext' => null,
             'image' => null,
         ];

--- a/tests/AutoCompleteTest.php
+++ b/tests/AutoCompleteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests;
+
+use ControlUIKit\AutoComplete;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Tests\Components\ComponentTestCase;
+
+class AutoCompleteTest extends ComponentTestCase
+{
+    /** @test */
+    public function autocomplete_can_be_rendered(): void
+    {
+        $class = new TestAutoComplete();
+
+        $this->assertSame(1, $class->count());
+        $this->assertIsArray($class->focus(1));
+        $this->assertIsArray($class->lookup(1));
+        $this->assertIsArray($class->preload());
+        $this->assertIsArray($class->search('test', 1));
+        $this->assertIsArray($class->language());
+    }
+}
+
+class TestAutoComplete extends AutoComplete
+{
+    public bool $auto = true;
+
+    public function count(): int
+    {
+       return 1;
+    }
+
+    public function focus(int $limit): Collection|array
+    {
+        return [];
+    }
+
+    public function lookup(int $id): Model|array
+    {
+        return [];
+    }
+
+    public function preload(): Collection|array
+    {
+        return $this->fields();
+    }
+
+    public function search(string $term, int $limit): Collection|array
+    {
+        return [
+            1 => $this->selectFields()
+        ];
+    }
+}
+


### PR DESCRIPTION
This PR updated the auto complete stub to reduce the need for the language() method in the default AutoComplete class