### PR TITLE
Chart Intersect Options

### DIFF
--- a/config/themes/default.php
+++ b/config/themes/default.php
@@ -474,7 +474,6 @@ return [
             'tooltips' => [
                 'enabled' => true,
                 'mode' => 'nearest',
-                'intersect' => true,
                 'position' => 'average',
                 'background-color' => 'rgb(--chart-tooltip-bg)',
                 'x-padding' => 6,
@@ -528,6 +527,7 @@ return [
         ],
 
         'pie' => [
+            'tooltip-intersect' => true,
             'segment' => [
                 'border-color' => '--chart-border',
                 'border-width' => 2,
@@ -545,6 +545,7 @@ return [
         ],
 
         'donut' => [
+            'tooltip-intersect' => true,
             'segment' => [
                 'border-color' => '--chart-border',
                 'border-width' => 2,
@@ -560,6 +561,26 @@ return [
             'layout' => [
                 'padding' => 0,
             ],
+        ],
+
+        'bar' => [
+            'tooltip-intersect' => true,
+        ],
+
+        'line' => [
+            'tooltip-intersect' => false,
+        ],
+
+        'column' => [
+            'tooltip-intersect' => true,
+        ],
+
+        'stacked' => [
+            'tooltip-intersect' => true,
+        ],
+
+        'combo' => [
+            'tooltip-intersect' => true,
         ],
     ],
 

--- a/resources/boost/skills/control-ui-kit-development/SKILL.md
+++ b/resources/boost/skills/control-ui-kit-development/SKILL.md
@@ -735,6 +735,29 @@ All modern API charts (Line, Column, Bar, Combo, Stacked) support these addition
 
 The default color palette is defined in `config/themes/default.php` under `charts.defaults.colors` as an array of CSS variable names (`'--chart-100'`, `'--chart-200'`, etc.). Datasets cycle through this palette if no `color` is specified.
 
+### Tooltip intersect (per chart type)
+
+Chart.js's `tooltip.intersect` option controls whether the tooltip requires the cursor to be visually inside a chart element before it shows. The default is **split per chart type** so each chart can ship with the right behaviour out of the box:
+
+| Chart | Config key | Default |
+|---|---|---|
+| Pie | `charts.pie.tooltip-intersect` | `true` |
+| Donut | `charts.donut.tooltip-intersect` | `true` |
+| Bar | `charts.bar.tooltip-intersect` | `false` |
+| Line | `charts.line.tooltip-intersect` | `false` |
+| Column | `charts.column.tooltip-intersect` | `false` |
+| Stacked | `charts.stacked.tooltip-intersect` | `false` |
+| Combo | `charts.combo.tooltip-intersect` | `false` |
+
+`true` is the right default for pie/donut — `mode: 'nearest'` + `intersect: false` on a circular chart can highlight a segment whose anchor is nearest the cursor rather than the one the cursor is actually over, producing wrong-segment tooltips. `false` is friendlier for bar/line where users expect the nearest data point to highlight without needing pixel-perfect hover.
+
+Override per instance with the `:tooltip-intersect` prop (note the leading colon — `strict_types=1` rejects bare string attributes against the `?bool` parameter):
+
+```blade
+<x-donut-chart id="d1" :data="$data" :tooltip-intersect="false" />
+<x-line-chart id="l1" :datasets="$ds" :labels="$lb" :tooltip-intersect="true" />
+```
+
 ---
 
 ## Maps

--- a/src/Components/Charts/Bar.php
+++ b/src/Components/Charts/Bar.php
@@ -16,6 +16,7 @@ class Bar extends Component
     protected string $legendLabel;
     protected string $defaultTitle;
     protected string $defaults = 'charts.defaults';
+    protected string $barConfig = 'charts.bar';
 
     public string $id;
     public array $datasets;
@@ -296,7 +297,7 @@ class Bar extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->barConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
 
@@ -396,7 +397,7 @@ class Bar extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Column.php
+++ b/src/Components/Charts/Column.php
@@ -16,6 +16,7 @@ class Column extends Component
     protected string $legendLabel;
     protected string $defaultTitle;
     protected string $defaults = 'charts.defaults';
+    protected string $columnConfig = 'charts.column';
 
     public string $id;
     public array $datasets;
@@ -317,7 +318,7 @@ class Column extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->columnConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
 
@@ -451,7 +452,7 @@ class Column extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Combo.php
+++ b/src/Components/Charts/Combo.php
@@ -16,6 +16,7 @@ class Combo extends Component
     protected string $legendLabel;
     protected string $defaultTitle;
     protected string $defaults = 'charts.defaults';
+    protected string $comboConfig = 'charts.combo';
 
     public string $id;
     public array $datasets;
@@ -308,7 +309,7 @@ class Combo extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->comboConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
 
@@ -501,7 +502,7 @@ class Combo extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Donut.php
+++ b/src/Components/Charts/Donut.php
@@ -235,7 +235,7 @@ class Donut extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->donutConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
         $this->tooltipTitleFamily = $this->style($this->defaults, 'tooltips.title-family', $tooltipTitleFamily);
@@ -365,7 +365,7 @@ class Donut extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Line.php
+++ b/src/Components/Charts/Line.php
@@ -16,6 +16,7 @@ class Line extends Component
     protected string $legendLabel;
     protected string $defaultTitle;
     protected string $defaults = 'charts.defaults';
+    protected string $lineConfig = 'charts.line';
 
     public string $id;
     public array $datasets;
@@ -320,7 +321,7 @@ class Line extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->lineConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
 
@@ -454,7 +455,7 @@ class Line extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Pie.php
+++ b/src/Components/Charts/Pie.php
@@ -16,6 +16,7 @@ class Pie extends Component
     protected string $legend = 'charts.defaults.legend';
     protected string $legendLabel = 'charts.defaults.legend.label';
     protected string $defaultTitle = 'charts.defaults.title';
+    protected string $pieConfig = 'charts.pie';
     protected string $pieSegment = 'charts.pie.segment';
     protected string $pieAnimation = 'charts.pie.animation';
     protected string $pieLayout = 'charts.pie.layout';
@@ -230,7 +231,7 @@ class Pie extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->pieConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
         $this->tooltipTitleFamily = $this->style($this->defaults, 'tooltips.title-family', $tooltipTitleFamily);
@@ -363,7 +364,7 @@ class Pie extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/src/Components/Charts/Stacked.php
+++ b/src/Components/Charts/Stacked.php
@@ -16,6 +16,7 @@ class Stacked extends Component
     protected string $legendLabel;
     protected string $defaultTitle;
     protected string $defaults = 'charts.defaults';
+    protected string $stackedConfig = 'charts.stacked';
 
     public string $id;
     public array $datasets;
@@ -302,7 +303,7 @@ class Stacked extends Component
 
         $this->tooltipEnabled = $this->style($this->defaults, 'tooltips.enabled', $tooltipEnabled);
         $this->tooltipMode = $this->style($this->defaults, 'tooltips.mode', $tooltipMode);
-        $this->tooltipIntersect = $this->style($this->defaults, 'tooltips.intersect', $tooltipIntersect);
+        $this->tooltipIntersect = $this->style($this->stackedConfig, 'tooltip-intersect', $tooltipIntersect);
         $this->tooltipPosition = $this->style($this->defaults, 'tooltips.position', $tooltipPosition);
         $this->tooltipBackgroundColor = $this->style($this->defaults, 'tooltips.background-color', $tooltipBackgroundColor);
 
@@ -437,7 +438,7 @@ class Stacked extends Component
                 'tooltip' => [
                     'enabled' => $this->tooltipEnabled !== 'false',
                     'mode' => $this->tooltipMode,
-                    'intersect' => $this->tooltipIntersect === 'false',
+                    'intersect' => filter_var($this->tooltipIntersect, FILTER_VALIDATE_BOOLEAN),
                     'position' => $this->tooltipPosition,
                     'backgroundColor' => $this->tooltipBackgroundColor,
                     'titleColor' => $this->tooltipTitleColor,

--- a/tests/Components/Tables/TableTest.php
+++ b/tests/Components/Tables/TableTest.php
@@ -788,7 +788,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_table_filters_classes_excludes_container_and_empty(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $classes = $table->tableFiltersClasses();
 
@@ -800,7 +800,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_table_filters_container_returns_container_value(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertSame('table-filters-container', $table->tableFiltersContainer());
     }
@@ -808,7 +808,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_table_filters_empty_returns_empty_value(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertNotEmpty($table->tableFiltersEmpty());
     }
@@ -816,7 +816,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_table_wrapper_with_filters_returns_value(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertSame('table-wrapper-with-filters', $table->tableWrapperWithFilters());
     }
@@ -824,7 +824,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_table_wrapper_without_filters_returns_value(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertSame('table-wrapper-without-filters', $table->tableWrapperWithoutFilters());
     }
@@ -832,7 +832,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_search_icon_classes_excludes_icon_and_size_keys(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $classes = $table->searchIconClasses();
 
@@ -842,7 +842,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_search_icon_size_returns_configured_value(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertSame('search-icon-size', $table->searchIconSize());
     }
@@ -850,7 +850,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_has_filters_returns_false_when_empty(): void
     {
-        $table = new Table();
+        $table = new Table;
 
         $this->assertFalse($table->hasFilters());
     }
@@ -1027,7 +1027,7 @@ class TableTest extends ComponentTestCase
     #[Test]
     public function table_active_filters_returns_select_type_with_collection_options(): void
     {
-        $opt = new \stdClass();
+        $opt = new \stdClass;
         $opt->value = 'active';
         $opt->label = 'Active';
 

--- a/tests/Console/ThemeUpdaterCommandTest.php
+++ b/tests/Console/ThemeUpdaterCommandTest.php
@@ -406,7 +406,7 @@ class ThemeUpdaterCommandTest extends ConsoleTestCase
     #[Test]
     public function trim_edge_blanks_removes_leading_and_trailing_blank_lines(): void
     {
-        $command = new ThemeUpdaterCommand();
+        $command = new ThemeUpdaterCommand;
 
         $method = new ReflectionMethod(ThemeUpdaterCommand::class, 'trimEdgeBlanks');
         $method->setAccessible(true);

--- a/tests/Helpers/Formatters/DecimalFormatterTest.php
+++ b/tests/Helpers/Formatters/DecimalFormatterTest.php
@@ -337,7 +337,7 @@ class DecimalFormatterTest extends TestCase
     #[Test]
     public function decimal_formatter_parse_falls_back_to_raw_data_for_unrecognised_rounding(): void
     {
-        $formatter = new DecimalFormatter();
+        $formatter = new DecimalFormatter;
 
         $rounding = new ReflectionProperty(DecimalFormatter::class, 'rounding');
         $rounding->setAccessible(true);

--- a/tests/Traits/UseThemeFileTest.php
+++ b/tests/Traits/UseThemeFileTest.php
@@ -94,7 +94,7 @@ class UseThemeFileTest extends TestCase
     }
 
     #[Test]
-    public function classList_filters_to_only_specified_keys(): void
+    public function class_list_filters_to_only_specified_keys(): void
     {
         $classes = [
             'background' => 'bg-white',


### PR DESCRIPTION
This update adds an intersect option for tool tips to show based on individual chart types, so we've got more explicit configuration and defaults.